### PR TITLE
Update API version to 65.0

### DIFF
--- a/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
+++ b/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <environments>Default</environments>
     <interviewLabel>Test SuperCombobox Auto-Output {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Test SuperCombobox Auto-Output</label>

--- a/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
+++ b/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Pick an Icon</masterLabel>
     <description>Icon Picker</description>

--- a/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>String Array Utils</description>
     <isExposed>false</isExposed>
     <masterLabel>String Array Utils</masterLabel>

--- a/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>Custom Property Editor for Super List Box LWC</description>
     <isExposed>false</isExposed>
     <masterLabel>Super List Box CPE</masterLabel>

--- a/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>Simple Dual-Listbox Flow Screen LWC</description>
     <isExposed>true</isExposed>
     <masterLabel>Super List Box LWC</masterLabel>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,5 +8,5 @@
   "name": "superBoxLWC",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "64.0"
+  "sourceApiVersion": "65.0"
 }


### PR DESCRIPTION
## Summary
- Updated API version from various versions (49.0-64.0) to 65.0 across all Salesforce metadata files
- Updated `sourceApiVersion` in `sfdx-project.json` to 65.0
- Changes affect 13 files: 2 Apex classes, 10 LWC components, 1 Flow

## Files Changed
### Apex Classes
- `SuperListBoxController.cls-meta.xml`: 61.0 → 65.0
- `SuperListBoxControllerTest.cls-meta.xml`: 61.0 → 65.0

### LWC Components
- `superListBoxLWC`: 61.0 → 65.0
- `superListBoxCPE`: 61.0 → 65.0
- `superComboboxLWC`: 61.0 → 65.0
- `superComboboxCPE`: 62.0 → 65.0
- `flowModalLauncher`: 58.0 → 65.0
- `fsc_pickIcon`: 64.0 → 65.0
- `fsc_pickIconCpe`: 64.0 → 65.0
- `stringArrayCombobox`: 61.0 → 65.0
- `stringArrayUtils`: 49.0 → 65.0

### Flow
- `Test_SuperCombobox_AutoOutput.flow-meta.xml`: 64.0 → 65.0

### Project Configuration
- `sfdx-project.json`: sourceApiVersion 64.0 → 65.0

## Test plan
- [ ] Deploy project to a Salesforce scratch org or sandbox
- [ ] Verify all LWC components render correctly in Flow Builder
- [ ] Test superListBoxLWC in a Flow screen
- [ ] Test superComboboxLWC in a Flow screen
- [ ] Run Apex tests to verify SuperListBoxController still works

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)