### PR TITLE
chore: update API version to 65.0

### DIFF
--- a/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
+++ b/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <environments>Default</environments>
-    <interviewLabel>Test SuperCombobox Auto-Output {!$Flow.CurrentDateTime}</interviewLabel>
+    <interviewLabel
+  >Test SuperCombobox Auto-Output {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Test SuperCombobox Auto-Output</label>
     <processMetadataValues>
         <name>BuilderType</name>
@@ -63,7 +64,8 @@
                     <booleanValue>true</booleanValue>
                 </value>
             </inputParameters>
-            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <inputsOnNextNavToAssocScrn
+      >UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>
@@ -71,7 +73,8 @@
         <showHeader>true</showHeader>
     </screens>
     <screens>
-        <description>Second combobox that can use the output from the first</description>
+        <description
+    >Second combobox that can use the output from the first</description>
         <name>Screen_2_Account_Rating</name>
         <label>Select Account Rating</label>
         <locationX>176</locationX>
@@ -113,10 +116,12 @@
             <inputParameters>
                 <name>initialSelectedValue</name>
                 <value>
-                    <elementReference>AccountTypeCombobox.selectedValue</elementReference>
+                    <elementReference
+          >AccountTypeCombobox.selectedValue</elementReference>
                 </value>
             </inputParameters>
-            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <inputsOnNextNavToAssocScrn
+      >UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>
@@ -134,7 +139,8 @@
         <allowPause>true</allowPause>
         <fields>
             <name>DisplayResults</name>
-            <fieldText>&lt;p&gt;&lt;b&gt;Selected Values:&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Account Type: {!AccountTypeCombobox.selectedValue}&lt;/p&gt;&lt;p&gt;Account Rating: {!AccountRatingCombobox.selectedValue}&lt;/p&gt;</fieldText>
+            <fieldText
+      >&lt;p&gt;&lt;b&gt;Selected Values:&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Account Type: {!AccountTypeCombobox.selectedValue}&lt;/p&gt;&lt;p&gt;Account Rating: {!AccountRatingCombobox.selectedValue}&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>

--- a/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
+++ b/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
@@ -1,15 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
-            <property name="flowName" type="String" required="true" description="API Name of the Flow to launch"/>
-            <property name="label" type="String" required="true" label="Button Label" default="Add Contact" description="Button Label"/>
-            <property name="inputVars" type="String" required="false" description="Input variable to pass to the Flow. Format: PropertyName::PropertyValue;Property2Name::Property2Value"/>
+            <property
+        name="flowName"
+        type="String"
+        required="true"
+        description="API Name of the Flow to launch"
+      />
+            <property
+        name="label"
+        type="String"
+        required="true"
+        label="Button Label"
+        default="Add Contact"
+        description="Button Label"
+      />
+            <property
+        name="inputVars"
+        type="String"
+        required="false"
+        description="Input variable to pass to the Flow. Format: PropertyName::PropertyValue;Property2Name::Property2Value"
+      />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Pick an Icon</masterLabel>
     <description>Icon Picker</description>
@@ -8,22 +8,68 @@
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
-        <targetConfig targets="lightning__FlowScreen" configurationEditor="c-fsc_pick-icon-cpe">
+        <targetConfig
+      targets="lightning__FlowScreen"
+      configurationEditor="c-fsc_pick-icon-cpe"
+    >
             <!-- Custom Property Editor (CPE) properties-->
-            <property name="iconCategories" type="String" role="inputOnly"/>
-            <property name="mode" label="Display Mode" type="String" description="Enter 'tab', 'accordion', or 'combobox'" role="inputOnly"/>
-            <property name="label" label="Label" type="String" default="Pick an Icon" role="inputOnly"/>
+            <property name="iconCategories" type="String" role="inputOnly" />
+            <property
+        name="mode"
+        label="Display Mode"
+        type="String"
+        description="Enter 'tab', 'accordion', or 'combobox'"
+        role="inputOnly"
+      />
+            <property
+        name="label"
+        label="Label"
+        type="String"
+        default="Pick an Icon"
+        role="inputOnly"
+      />
 
-            <property name="iconName" label="Icon Name" type="String"/>
+            <property name="iconName" label="Icon Name" type="String" />
 
             <!-- These properties are available to be set via API but are not exposed in the CPE -->
-            <property name="hideStandardIcons" label="Hide Standard icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="hideCustomIcons" label="Hide Custom icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="hideUtilityIcons" label="Hide Utility icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="hideActionIcons" label="Hide Action icons" type="Boolean" default="false" description="Note: Action icons are not available in combobox mode" role="inputOnly"/>
+            <property
+        name="hideStandardIcons"
+        label="Hide Standard icons"
+        type="Boolean"
+        default="false"
+        role="inputOnly"
+      />
+            <property
+        name="hideCustomIcons"
+        label="Hide Custom icons"
+        type="Boolean"
+        default="false"
+        role="inputOnly"
+      />
+            <property
+        name="hideUtilityIcons"
+        label="Hide Utility icons"
+        type="Boolean"
+        default="false"
+        role="inputOnly"
+      />
+            <property
+        name="hideActionIcons"
+        label="Hide Action icons"
+        type="Boolean"
+        default="false"
+        description="Note: Action icons are not available in combobox mode"
+        role="inputOnly"
+      />
 
             <!-- Legacy properties -->
-            <property name="accordionMode" label="zzz(legacy) Accordion Mode" description="This is a legacy property included for backwards compatibility and is not recommended for future use. Use the new 'mode' property instead." type="boolean" role="inputOnly"/>
+            <property
+        name="accordionMode"
+        label="zzz(legacy) Accordion Mode"
+        description="This is a legacy property included for backwards compatibility and is not recommended for future use. Use the new 'mode' property instead."
+        type="boolean"
+        role="inputOnly"
+      />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>64.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>String Array Utils</description>
     <isExposed>false</isExposed>
     <masterLabel>String Array Utils</masterLabel>

--- a/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
@@ -1,21 +1,83 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
-        <targetConfig targets="lightning__FlowScreen" configurationEditor="c-super-combobox-c-p-e">
-            <property name="objectApiName" type="String" required="true" role="inputOnly" label="Object API Name" description="The API name of the object containing the picklist field"/>
-            <property name="fieldApiName" type="String" required="true" role="inputOnly" label="Field API Name" description="The API name of the picklist field"/>
-            <property name="recordTypeId" type="String" role="inputOnly" label="Record Type ID" description="Optional: Specify a Record Type ID to filter picklist values"/>
-            <property name="cardTitle" type="String" role="inputOnly" label="Card Title" default="Select Value" description="The title displayed at the top of the component"/>
-            <property name="placeholder" type="String" role="inputOnly" label="Placeholder Text" default="Choose a value" description="Placeholder text shown when no value is selected"/>
-            <property name="isRequired" type="Boolean" role="inputOnly" label="Is Required" default="false" description="Whether a selection is required"/>
-            <property name="initialSelectedValue" type="String" role="inputOnly" label="Initial Selected Value" description="Pre-selected value when the component loads"/>
-            <property name="picklistDefinitions" type="String" role="inputOnly" label="Picklist Definitions" description="JSON string containing picklist values from CPE"/>
-            <property name="selectedValue" type="String" role="outputOnly" label="Selected Value" description="The value selected by the user"/>
+        <targetConfig
+      targets="lightning__FlowScreen"
+      configurationEditor="c-super-combobox-c-p-e"
+    >
+            <property
+        name="objectApiName"
+        type="String"
+        required="true"
+        role="inputOnly"
+        label="Object API Name"
+        description="The API name of the object containing the picklist field"
+      />
+            <property
+        name="fieldApiName"
+        type="String"
+        required="true"
+        role="inputOnly"
+        label="Field API Name"
+        description="The API name of the picklist field"
+      />
+            <property
+        name="recordTypeId"
+        type="String"
+        role="inputOnly"
+        label="Record Type ID"
+        description="Optional: Specify a Record Type ID to filter picklist values"
+      />
+            <property
+        name="cardTitle"
+        type="String"
+        role="inputOnly"
+        label="Card Title"
+        default="Select Value"
+        description="The title displayed at the top of the component"
+      />
+            <property
+        name="placeholder"
+        type="String"
+        role="inputOnly"
+        label="Placeholder Text"
+        default="Choose a value"
+        description="Placeholder text shown when no value is selected"
+      />
+            <property
+        name="isRequired"
+        type="Boolean"
+        role="inputOnly"
+        label="Is Required"
+        default="false"
+        description="Whether a selection is required"
+      />
+            <property
+        name="initialSelectedValue"
+        type="String"
+        role="inputOnly"
+        label="Initial Selected Value"
+        description="Pre-selected value when the component loads"
+      />
+            <property
+        name="picklistDefinitions"
+        type="String"
+        role="inputOnly"
+        label="Picklist Definitions"
+        description="JSON string containing picklist values from CPE"
+      />
+            <property
+        name="selectedValue"
+        type="String"
+        role="outputOnly"
+        label="Selected Value"
+        description="The value selected by the user"
+      />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>Custom Property Editor for Super List Box LWC</description>
     <isExposed>false</isExposed>
     <masterLabel>Super List Box CPE</masterLabel>

--- a/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <description>Simple Dual-Listbox Flow Screen LWC</description>
     <isExposed>true</isExposed>
     <masterLabel>Super List Box LWC</masterLabel>
@@ -8,19 +8,82 @@
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
-        <targetConfig targets="lightning__FlowScreen" configurationEditor="c-super-list-box-c-p-e">
-            <property name="objectApiName" type="String" label="Object API Name" />
-            <property name="fieldApiName" type="String" label="Field API Name" />
-            <property name="selectedAsString" type="String" label="Selected Values as String" role="outputOnly" />
-            <property name="selectedAsCollection" type="String[]" label="Selected values as String Collection" role="outputOnly" />
-            <property name="recordTypeId" type="String" label="RecordTypeID to filter picklist values (Optional)" />
-            <property name="cardTitle" type="String" label="Label" default="Select Values" />
-            <property name="isRequired" type="Boolean" label="Is Input Required?" default="false" />
-            <property name="initialSelectedValues" type="String[]" label="Initial Selected Values" description="Pass in 'selectedAsCollection' to re-use already selected values." default="[]" />
-            <property name="picklistDefinitions" type="String" label="Custom Picklist Definitions" description="JSON string containing custom help text for picklist values" />
-            <property name="helpTextDisplayMode" type="String" label="Help Text Display Mode" description="Display mode for help text: bubble or subtitle" default="bubble" />
-            <property name="picklistIcons" type="String" label="Custom Picklist Icons" description="JSON string containing icon mappings for picklist values" />
-            <property name="enableOptionIcons" type="Boolean" label="Enable Option Icons" description="Show icons next to picklist options" default="false" />
+        <targetConfig
+      targets="lightning__FlowScreen"
+      configurationEditor="c-super-list-box-c-p-e"
+    >
+            <property
+        name="objectApiName"
+        type="String"
+        label="Object API Name"
+      />
+            <property
+        name="fieldApiName"
+        type="String"
+        label="Field API Name"
+      />
+            <property
+        name="selectedAsString"
+        type="String"
+        label="Selected Values as String"
+        role="outputOnly"
+      />
+            <property
+        name="selectedAsCollection"
+        type="String[]"
+        label="Selected values as String Collection"
+        role="outputOnly"
+      />
+            <property
+        name="recordTypeId"
+        type="String"
+        label="RecordTypeID to filter picklist values (Optional)"
+      />
+            <property
+        name="cardTitle"
+        type="String"
+        label="Label"
+        default="Select Values"
+      />
+            <property
+        name="isRequired"
+        type="Boolean"
+        label="Is Input Required?"
+        default="false"
+      />
+            <property
+        name="initialSelectedValues"
+        type="String[]"
+        label="Initial Selected Values"
+        description="Pass in 'selectedAsCollection' to re-use already selected values."
+        default="[]"
+      />
+            <property
+        name="picklistDefinitions"
+        type="String"
+        label="Custom Picklist Definitions"
+        description="JSON string containing custom help text for picklist values"
+      />
+            <property
+        name="helpTextDisplayMode"
+        type="String"
+        label="Help Text Display Mode"
+        description="Display mode for help text: bubble or subtitle"
+        default="bubble"
+      />
+            <property
+        name="picklistIcons"
+        type="String"
+        label="Custom Picklist Icons"
+        description="JSON string containing icon mappings for picklist values"
+      />
+            <property
+        name="enableOptionIcons"
+        type="Boolean"
+        label="Enable Option Icons"
+        description="Show icons next to picklist options"
+        default="false"
+      />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
 		<members>*</members>
@@ -35,5 +35,5 @@
 		<members>*</members>
 		<name>StaticResource</name>
 	</types>
-	<version>64.0</version>
+	<version>65.0</version>
 </Package>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,5 +8,5 @@
   "name": "superBoxLWC",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "64.0"
+  "sourceApiVersion": "65.0"
 }


### PR DESCRIPTION
## Summary
- Updated all Salesforce metadata API versions to 65.0
- Updated `sfdx-project.json` sourceApiVersion from 64.0 to 65.0
- Updated `manifest/package.xml` version from 64.0 to 65.0
- Updated 10 LWC component meta.xml files (from versions 49.0-64.0)
- Updated 2 Apex class meta.xml files (from version 61.0)
- Updated 1 Flow meta.xml file (from version 64.0)

## Files Updated (14 total)

### Configuration Files
- `sfdx-project.json` - 64.0 → 65.0
- `manifest/package.xml` - 64.0 → 65.0

### LWC Components (10 files)
- `superListBoxLWC.js-meta.xml` - 61.0 → 65.0
- `superListBoxCPE.js-meta.xml` - 61.0 → 65.0
- `superComboboxLWC.js-meta.xml` - 61.0 → 65.0
- `superComboboxCPE.js-meta.xml` - 62.0 → 65.0
- `stringArrayCombobox.js-meta.xml` - 61.0 → 65.0
- `stringArrayUtils.js-meta.xml` - 49.0 → 65.0
- `flowModalLauncher.js-meta.xml` - 58.0 → 65.0
- `fsc_pickIcon.js-meta.xml` - 64.0 → 65.0
- `fsc_pickIconCpe.js-meta.xml` - 64.0 → 65.0

### Apex Classes (2 files)
- `SuperListBoxController.cls-meta.xml` - 61.0 → 65.0
- `SuperListBoxControllerTest.cls-meta.xml` - 61.0 → 65.0

### Flows (1 file)
- `Test_SuperCombobox_AutoOutput.flow-meta.xml` - 64.0 → 65.0

## Test plan
- [ ] Verify deployment to scratch org succeeds with `sf project deploy start`
- [ ] Verify all LWC components render correctly in Flow screens
- [ ] Verify Apex tests still pass with `sf apex test run --test-level RunLocalTests`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)