### PR TITLE
fix: remove default inputVariables from flowModalLauncher

### DIFF
--- a/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js
+++ b/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js
@@ -9,29 +9,22 @@ export default class FlowModalLauncher extends LightningElement {
   isModalOpen = false;
 
   get inputVariables() {
-    // If inputVars is null (or falsy), return the default configuration
+    // If inputVars is null or empty, return empty array (no default variables)
     if (!this.inputVars) {
-      return [
-        {
-          name: 'accId',
-          type: 'String',
-          value: this.inputVars
-        }
-      ];
-    } else {
-      // Otherwise, assume inputVars is a string in the format:
-      // "PropertyName::PropertyValue;Property2Name::Property2Value"
-      // Split the string on semicolons to get each key-value pair
-      return this.inputVars.split(';').map(pair => {
-        // Split each pair on "::" to separate the property name from its value
-        const [propName, propValue] = pair.split('::');
-        return {
-          name: propName.trim(),
-          type: 'String',
-          value: propValue.trim()
-        };
-      });
+      return [];
     }
+    // Parse inputVars string in the format:
+    // "PropertyName::PropertyValue;Property2Name::Property2Value"
+    // Split the string on semicolons to get each key-value pair
+    return this.inputVars.split(';').map(pair => {
+      // Split each pair on "::" to separate the property name from its value
+      const [propName, propValue] = pair.split('::');
+      return {
+        name: propName.trim(),
+        type: 'String',
+        value: propValue.trim()
+      };
+    });
   }
 
   handleClick() {


### PR DESCRIPTION
## Summary

- Removes hardcoded default input variable (`accId`) from `inputVariables` getter in `flowModalLauncher.js`
- Returns an empty array `[]` when `inputVars` is null/empty instead of a default configuration
- Ensures only user-defined input variables are passed to the flow

## Problem

The `inputVariables` getter was returning:
```javascript
return [
  {
    name: 'accId',
    type: 'String',
    value: this.inputVars  // null
  }
];
```

This caused the flow to receive an unwanted default variable named `accId` with a null value, even when users hadn't defined any input variables.

## Solution

Now when `inputVars` is null/empty, the getter returns an empty array `[]`. This follows the pattern used in other Flow components (e.g., [UnofficialSF/LightningFlowComponents](https://github.com/UnofficialSF/LightningFlowComponents)).

## Test plan

- [ ] Verify component works when no input variables are provided (should pass empty array to flow)
- [ ] Verify component correctly parses user-defined input variables in format `name::value;name2::value2`
- [ ] Test in a Flow screen to ensure no unexpected variables are passed

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)