### PR TITLE
fix(apex,lwc): Downgrade API Version from 65.0 to 64.0

### DIFF
--- a/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/SuperListBoxControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
+++ b/force-app/main/default/flows/Test_SuperCombobox_AutoOutput.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <environments>Default</environments>
     <interviewLabel>Test SuperCombobox Auto-Output {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Test SuperCombobox Auto-Output</label>

--- a/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
+++ b/force-app/main/default/lwc/flowModalLauncher/flowModalLauncher.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Pick an Icon</masterLabel>
     <description>Icon Picker</description>

--- a/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
+++ b/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayCombobox/stringArrayCombobox.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
+++ b/force-app/main/default/lwc/stringArrayUtils/stringArrayUtils.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>String Array Utils</description>
     <isExposed>false</isExposed>
     <masterLabel>String Array Utils</masterLabel>

--- a/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxCPE/superComboboxCPE.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superComboboxLWC/superComboboxLWC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxCPE/superListBoxCPE.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Custom Property Editor for Super List Box LWC</description>
     <isExposed>false</isExposed>
     <masterLabel>Super List Box CPE</masterLabel>

--- a/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
+++ b/force-app/main/default/lwc/superListBoxLWC/superListBoxLWC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>65.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Simple Dual-Listbox Flow Screen LWC</description>
     <isExposed>true</isExposed>
     <masterLabel>Super List Box LWC</masterLabel>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,5 +8,5 @@
   "name": "superBoxLWC",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "65.0"
+  "sourceApiVersion": "64.0"
 }


### PR DESCRIPTION
## Summary
- Downgrade all Salesforce API version references from 65.0 to 64.0 as requested in issue #8
- This ensures compatibility with Salesforce orgs running API version 64.0

## Salesforce Components Changed
- [x] Apex Classes: `SuperListBoxController.cls-meta.xml`, `SuperListBoxControllerTest.cls-meta.xml`
- [x] LWC: `superListBoxLWC`, `superListBoxCPE`, `superComboboxLWC`, `superComboboxCPE`, `stringArrayCombobox`, `stringArrayUtils`, `fsc_pickIcon`, `fsc_pickIconCpe`, `flowModalLauncher`
- [x] Flows: `Test_SuperCombobox_AutoOutput.flow-meta.xml`
- [x] Project Config: `sfdx-project.json`

## Testing
- [ ] Apex tests pass (75%+ coverage)
- [ ] Manual testing in Flow screen after deployment

## Deployment Notes
No special deployment order required - all changes are metadata version updates only.

---
Closes #8
🤖 Generated with [Claude Code](https://claude.com/claude-code)